### PR TITLE
perf(stream): create singleton stream

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_install:
 before_script:
   - npm prune
 after_success:
+  - nyc npm test && nyc report --reporter=text-lcov | coveralls  
   - npm run semantic-release
 branches:
   except:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # Reactive Storage
-[![Build Status](https://travis-ci.org/tusharmath/reactive-storage.svg?branch=master)](https://travis-ci.org/tusharmath/reactive-storage)
-[![npm](https://img.shields.io/npm/v/reactive-storage.svg)](https://www.npmjs.com/package/reactive-storage)
+[![Build Status][travis-svg]][travis]
+[![npm][npm-svg]][npm]
+
+[travis-svg]: https://travis-ci.org/tusharmath/reactive-storage.svg?branch=master
+[travis]: https://travis-ci.org/tusharmath/reactive-storage
+[npm-svg]: https://img.shields.io/npm/v/reactive-storage.svg
+[npm]: https://www.npmjs.com/package/reactive-storage
+
 
 
 A module that does the following things —
@@ -60,7 +66,7 @@ store.set(100)
 
 - `get()`: Returns the current value of the store.
 
-- `stream`: Exposes the store as a stream. Useful for [react-announce-connect](https://travis-ci.org/tusharmath/react-announce-connect) 
+- `stream`: Exposes the store as a stream. Useful for [react-announce-connect](https://travis-ci.org/tusharmath/react-announce-connect)
 
 - `undo()`: Goes back a previous state.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Reactive Storage 
+# Reactive Storage
 [![Build Status](https://travis-ci.org/tusharmath/reactive-storage.svg?branch=master)](https://travis-ci.org/tusharmath/reactive-storage)
 [![npm](https://img.shields.io/npm/v/reactive-storage.svg)](https://www.npmjs.com/package/reactive-storage)
 
@@ -36,11 +36,11 @@ const store = create(new Immutable({a: 1, b: 2}), 30)
 * Automatically logs every change in the store.
 * Change detection is done via `===` comparison between the initial and the final store values.
 */
-store.getStream().subscribe(x => console.log(x))
+store.stream.subscribe(x => console.log(x))
 
 
 /*
-* Changes to the store can be made via the `update` function which takes a `callback` as a param. The `callback` is called with the current value of the store. 
+* Changes to the store can be made via the `update` function which takes a `callback` as a param. The `callback` is called with the current value of the store.
 */
 
 store.set(x => x.set('a', 100)
@@ -60,7 +60,7 @@ store.set(100)
 
 - `get()`: Returns the current value of the store.
 
-- `getStream()`: Exposes the store as a stream. Useful for [react-announce-connect](https://travis-ci.org/tusharmath/react-announce-connect) 
+- `stream`: Exposes the store as a stream. Useful for [react-announce-connect](https://travis-ci.org/tusharmath/react-announce-connect) 
 
 - `undo()`: Goes back a previous state.
 

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ exports.create = exports.createStoreStream = (value, limit) => {
   var UNDO_HISTORY = []
   var REDO_HISTORY = []
 
-  const stream = new BehaviorSubject(value)
+  const subject = new BehaviorSubject(value)
   const dispatchValue = (_value, push) => {
     var isDefined = _value !== undefined
     var isDiff = value !== _value
@@ -36,24 +36,24 @@ exports.create = exports.createStoreStream = (value, limit) => {
 
     if ([isDefined, isDiff].every(Boolean)) {
       value = _value
-      stream.onNext(value)
+      subject.onNext(value)
     }
   }
   const reset = () => {
     REDO_HISTORY = []
     UNDO_HISTORY = []
   }
-  const _stream = stream.filter(x => x !== ignoredValues)
+
   return {
-    stream: _stream,
+    stream: subject.filter(x => x !== ignoredValues),
     set: cb => {
       REDO_HISTORY = []
       dispatchValue(typeof cb === 'function' ? cb(value) : cb, true)
-      return stream
+      return subject
     },
     end: () => {
       reset()
-      stream.onCompleted()
+      subject.onCompleted()
     },
     get: () => value,
     undo: () => dispatchValue(UNDO_HISTORY.pop(), false),

--- a/index.js
+++ b/index.js
@@ -39,12 +39,13 @@ exports.create = exports.createStoreStream = (value, limit) => {
       stream.onNext(value)
     }
   }
-  var reset = () => {
+  const reset = () => {
     REDO_HISTORY = []
     UNDO_HISTORY = []
   }
+  const _stream = stream.filter(x => x !== ignoredValues)
   return {
-    getStream: () => stream.filter(x => x !== ignoredValues),
+    stream: _stream,
     set: cb => {
       REDO_HISTORY = []
       dispatchValue(typeof cb === 'function' ? cb(value) : cb, true)

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "./index.js",
   "author": "tusharmath@gmail.com",
   "license": "ISC",
-  "peerDependencies":{
+  "peerDependencies": {
     "rx": "^4.0.6"
   },
   "scripts": {
@@ -17,9 +17,11 @@
   },
   "devDependencies": {
     "ava": "^0.11.0",
+    "coveralls": "^2.11.8",
     "cz-conventional-changelog": "^1.1.5",
-    "semantic-release": "^4.3.5",
-    "rx": "^4.0.6"
+    "nyc": "^5.6.0",
+    "rx": "^4.0.6",
+    "semantic-release": "^4.3.5"
   },
   "keywords": [
     "reactive",

--- a/test.js
+++ b/test.js
@@ -10,7 +10,7 @@ import {createStoreStream} from './'
 test('constructor()', t => {
   const out = []
   const store = createStoreStream()
-  store.getStream().subscribe(x => out.push(x))
+  store.stream.subscribe(x => out.push(x))
   store.set(x => 200)
   store.set(x => 300)
   t.same(out, [200, 300])
@@ -19,7 +19,7 @@ test('constructor()', t => {
 test('update(function)', t => {
   const out = []
   const store = createStoreStream(100)
-  store.getStream().subscribe(x => out.push(x))
+  store.stream.subscribe(x => out.push(x))
   store.set(x => 200)
   store.set(x => 300)
   t.same(out, [100, 200, 300])
@@ -28,7 +28,7 @@ test('update(function)', t => {
 test('update(value)', t => {
   const out = []
   const store = createStoreStream(100)
-  store.getStream().subscribe(x => out.push(x))
+  store.stream.subscribe(x => out.push(x))
   store.set(200)
   store.set(300)
   t.same(out, [100, 200, 300])
@@ -37,7 +37,7 @@ test('update(value)', t => {
 test('update(value):distinct', t => {
   const out = []
   const store = createStoreStream(100)
-  store.getStream().subscribe(x => out.push(x))
+  store.stream.subscribe(x => out.push(x))
   store.set(200)
   store.set(200)
   t.same(out, [100, 200])
@@ -46,7 +46,7 @@ test('update(value):distinct', t => {
 test('undo():single', t => {
   const out = []
   const store = createStoreStream(100, 100)
-  store.getStream().subscribe(x => out.push(x))
+  store.stream.subscribe(x => out.push(x))
   store.set(200)
   store.set(300)
   store.set(400)
@@ -57,7 +57,7 @@ test('undo():single', t => {
 test('undo()', t => {
   const out = []
   const store = createStoreStream(100, 100)
-  store.getStream().subscribe(x => out.push(x))
+  store.stream.subscribe(x => out.push(x))
   store.set(200)
   store.set(300)
   store.set(400)
@@ -72,7 +72,7 @@ test('undo()', t => {
 test('redo+undo', t => {
   const out = []
   const store = createStoreStream(void 0, 100)
-  store.getStream().subscribe(x => out.push(x))
+  store.stream.subscribe(x => out.push(x))
   store.set(100) // 100
   store.set(200) // 200
   store.set(300) // 300
@@ -94,7 +94,7 @@ test('redo+undo', t => {
 test('redo+undo+update', t => {
   const out = []
   const store = createStoreStream(void 0, 100)
-  store.getStream().subscribe(x => out.push(x))
+  store.stream.subscribe(x => out.push(x))
   store.set(100)
   store.set(200)
   store.set(300)
@@ -110,7 +110,7 @@ test('redo+undo+update', t => {
 test('history-limit:2', t => {
   const out = []
   const store = createStoreStream(0, 2)
-  store.getStream().subscribe(x => out.push(x))
+  store.stream.subscribe(x => out.push(x))
   store.set(100)
   store.set(200)
   store.set(300)
@@ -125,7 +125,7 @@ test('history-limit:2', t => {
 test('history-limit:default', t => {
   const out = []
   const store = createStoreStream(0)
-  store.getStream().subscribe(x => out.push(x))
+  store.stream.subscribe(x => out.push(x))
   store.set(100)
   store.set(200)
   store.set(300)
@@ -140,7 +140,7 @@ test('history-limit:default', t => {
 test('canUndo(),canRedo()', t => {
   const out = []
   const store = createStoreStream(0, 2)
-  store.getStream().subscribe(x => out.push(x))
+  store.stream.subscribe(x => out.push(x))
   store.set(100)
   t.true(store.canUndo)
   t.false(store.canRedo)
@@ -152,7 +152,7 @@ test('canUndo(),canRedo()', t => {
 test('reset()', t => {
   const out = []
   const store = createStoreStream(0, 2)
-  store.getStream().subscribe(x => out.push(x))
+  store.stream.subscribe(x => out.push(x))
   store.set(100)
   store.set(100)
   store.set(100)
@@ -164,7 +164,7 @@ test('reset()', t => {
 test('end()', t => {
   const out = []
   const store = createStoreStream(0, 2)
-  store.getStream().subscribe(
+  store.stream.subscribe(
     x => out.push(x),
     null,
     () => out.push('completed'))
@@ -176,7 +176,7 @@ test('end()', t => {
 test('end():history', t => {
   const out = []
   const store = createStoreStream(0, 2)
-  store.getStream().subscribe(
+  store.stream.subscribe(
     x => out.push(x),
     null,
     () => out.push('completed'))
@@ -184,4 +184,9 @@ test('end():history', t => {
   store.end()
   t.false(store.canUndo)
   t.false(store.canRedo)
+})
+
+test('stream:same instance', t => {
+  const store = createStoreStream(1)
+  t.same(store.stream, store.stream)
 })


### PR DESCRIPTION
stream is exposed as a property instead of a function call

BREAKING CHANGE: use 'store.stream' instead of 'store.getStream()'